### PR TITLE
Separate Allowed Protocol List (Link & Plain Text)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ This plugin allows you to filter / surpress links in posts on your Mattermost se
 ### Usage
 
 You can edit the plugin configuration in **System Console > Plugins > Embedded Link Filter***
-* **Allowed Protocols list**<br>
-  This denotes the list of protocols to allow, separated by commas.<br/>
+* **Allowed Protocols lists**<br>
+ This denotes the list of protocols to allow, separated by commas.<br/>
  For example, `http,https` will allow messages with links like `https://github.com` or `http://github.com` but reject posts containing links like `s3://YourS3Bucket/dir/filename.filetype`.
+ One list allows for [formatted links](https://docs.mattermost.com/messaging/formatting-text.html#links) the other allows for plain text links.
 
 * **New Post Warning Message**<br>
   This denotes the message that is shown when a new post is created and gets rejected.

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "mattermost-plugin-link-filter",
   "name": "Embedded Link Filter",
-  "version": "1.0.5",
+  "version": "1.0.7",
   "min_server_version": "5.2.0",
   "server": {
     "executables": {

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "mattermost-plugin-link-filter",
   "name": "Embedded Link Filter",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "min_server_version": "5.2.0",
   "server": {
     "executables": {
@@ -35,10 +35,18 @@
         "default": "Your edit has been rejected by the Link Filter."
       },
       {
-        "key": "AllowedProtocolList",
-        "display_name": "Allowed Protocols List:",
+        "key": "AllowedProtocolListLink",
+        "display_name": "Allowed Protocols List (Link):",
         "type": "text",
-        "help_text": "The protocols to allow, separated by commas. Capitalization and punctuation insensitive.",
+        "help_text": "The protocols to allow in a link, separated by commas. Capitalization and punctuation insensitive.",
+        "placeholder": "E.g., http, https, mailto, mattermost",
+        "default": "http,https,mailto,mattermost"
+      },
+      {
+        "key": "AllowedProtocolListPlainText",
+        "display_name": "Allowed Protocols List (Plain Text):",
+        "type": "text",
+        "help_text": "The protocols to allow in plain text, separated by commas. Capitalization and punctuation insensitive.",
         "placeholder": "E.g., http, https, mailto, mattermost",
         "default": "http,https,mailto,mattermost"
       }

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -23,10 +23,11 @@ import (
 // If you add non-reference types to your configuration struct, be sure to rewrite Clone as a deep
 // copy appropriate for your types.
 type configuration struct {
-	RejectPlainLinks         bool
-	AllowedProtocolList      string
-	CreatePostWarningMessage string
-	EditPostWarningMessage   string
+	RejectPlainLinks             bool
+	AllowedProtocolListLink      string
+	AllowedProtocolListPlainText string
+	CreatePostWarningMessage     string
+	EditPostWarningMessage       string
 }
 
 // Clone shallow copies the configuration. Your implementation may require a deep copy if
@@ -88,14 +89,21 @@ func (p *Plugin) OnConfigurationChange() error {
 
 	p.setConfiguration(configuration)
 
-	// Addind space around the words
-	regexString := wordListToRegex(configuration.AllowedProtocolList)
-	regex, err := regexp.Compile(regexString)
+	// Addind space around the words (Link)
+	regexStringLink := wordListToRegex(configuration.AllowedProtocolListLink)
+	regexLink, err := regexp.Compile(regexStringLink)
 	if err != nil {
 		return err
 	}
+	p.allowedProtocolsRegexLink = regexLink
 
-	p.allowedProtocolsRegex = regex
+	// Addind space around the words (Plain Text)
+	regexStringPlainText := wordListToRegex(configuration.AllowedProtocolListPlainText)
+	regexPlainText, err := regexp.Compile(regexStringPlainText)
+	if err != nil {
+		return err
+	}
+	p.allowedProtocolsRegexPlainText = regexPlainText
 
 	return nil
 }

--- a/server/configuration_test.go
+++ b/server/configuration_test.go
@@ -9,24 +9,24 @@ import (
 func TestWordListToRegex(t *testing.T) {
 	p := Plugin{
 		configuration: &configuration{
-			AllowedProtocolList: "https,http,mailto",
+			AllowedProtocolListLink: "https,http,mailto",
 		},
 	}
 
 	t.Run("Build Regex", func(t *testing.T) {
-		regexStr := wordListToRegex(p.getConfiguration().AllowedProtocolList)
+		regexStr := wordListToRegex(p.getConfiguration().AllowedProtocolListLink)
 
 		assert.Equal(t, regexStr, `(?mi)\b(https|http|mailto)\b`)
 	})
 
 	p2 := Plugin{
 		configuration: &configuration{
-			AllowedProtocolList: "https, http, mailto",
+			AllowedProtocolListLink: "https, http, mailto",
 		},
 	}
 
 	t.Run("Build Regex with extra space", func(t *testing.T) {
-		regexStr := wordListToRegex(p2.getConfiguration().AllowedProtocolList)
+		regexStr := wordListToRegex(p2.getConfiguration().AllowedProtocolListLink)
 
 		assert.Equal(t, regexStr, `(?mi)\b(https|http|mailto)\b`)
 	})

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -7,5 +7,5 @@ var manifest = struct {
 	Version string
 }{
 	ID:      "mattermost-plugin-link-filter",
-	Version: "1.0.5",
+	Version: "1.0.7",
 }

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -7,5 +7,5 @@ var manifest = struct {
 	Version string
 }{
 	ID:      "mattermost-plugin-link-filter",
-	Version: "1.0.4",
+	Version: "1.0.5",
 }

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -18,10 +18,11 @@ type Plugin struct {
 
 	// configuration is the active plugin configuration. Consult getConfiguration and
 	// setConfiguration for usage.
-	configuration         *configuration
-	embeddedLinkRegex     *regexp.Regexp
-	plainLinkRegex        *regexp.Regexp
-	allowedProtocolsRegex *regexp.Regexp
+	configuration                  *configuration
+	embeddedLinkRegex              *regexp.Regexp
+	plainLinkRegex                 *regexp.Regexp
+	allowedProtocolsRegexLink      *regexp.Regexp
+	allowedProtocolsRegexPlainText *regexp.Regexp
 }
 
 const (
@@ -72,6 +73,7 @@ func (p *Plugin) getInvalidURLs(post *model.Post) []string {
 		// [6-7] start and end position of "host"
 		protocolStartIndex := loc[4]
 		procolEndIndex := loc[5]
+		isPlainText := false
 
 		// The case when detected url has length 6 i.e., the url is plain link
 		// then the detected url will have no "text" and
@@ -79,11 +81,16 @@ func (p *Plugin) getInvalidURLs(post *model.Post) []string {
 		if len(loc) == 6 {
 			protocolStartIndex = loc[2]
 			procolEndIndex = loc[3]
+			isPlainText = true
 		}
 
 		protocol := string(postText[protocolStartIndex:procolEndIndex])
 		_, ok := set[protocol]
-		if !ok && (len(configuration.AllowedProtocolList) == 0 || !p.allowedProtocolsRegex.MatchString(protocol)) {
+		if !ok && !isPlainText && (len(configuration.AllowedProtocolListLink) == 0 || !p.allowedProtocolsRegexLink.MatchString(protocol)) {
+			invalidURLProtocols = append(invalidURLProtocols, protocol)
+			set[protocol] = true
+		}
+		if !ok && isPlainText && (len(configuration.AllowedProtocolListPlainText) == 0 || !p.allowedProtocolsRegexPlainText.MatchString(protocol)) {
 			invalidURLProtocols = append(invalidURLProtocols, protocol)
 			set[protocol] = true
 		}

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -12,13 +12,15 @@ import (
 func TestGetInvalidURLs(t *testing.T) {
 	p := Plugin{
 		configuration: &configuration{
-			RejectPlainLinks:        true,
-			AllowedProtocolListLink: "http,https,mailto",
+			RejectPlainLinks:             true,
+			AllowedProtocolListLink:      "http,https,mailto",
+			AllowedProtocolListPlainText: "http,https,mailto",
 		},
 	}
 	p.plainLinkRegex = regexp.MustCompile(PlainLinkRegexString)
 	p.embeddedLinkRegex = regexp.MustCompile(EmbeddedLinkRegexString)
 	p.allowedProtocolsRegexLink = regexp.MustCompile(wordListToRegex(p.getConfiguration().AllowedProtocolListLink))
+	p.allowedProtocolsRegexPlainText = regexp.MustCompile(wordListToRegex(p.getConfiguration().AllowedProtocolListPlainText))
 
 	t.Run("link protocol matches allowed protocol list", func(t *testing.T) {
 		in := &model.Post{

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -12,13 +12,13 @@ import (
 func TestGetInvalidURLs(t *testing.T) {
 	p := Plugin{
 		configuration: &configuration{
-			RejectPlainLinks:    true,
-			AllowedProtocolList: "http,https,mailto",
+			RejectPlainLinks:        true,
+			AllowedProtocolListLink: "http,https,mailto",
 		},
 	}
 	p.plainLinkRegex = regexp.MustCompile(PlainLinkRegexString)
 	p.embeddedLinkRegex = regexp.MustCompile(EmbeddedLinkRegexString)
-	p.allowedProtocolsRegex = regexp.MustCompile(wordListToRegex(p.getConfiguration().AllowedProtocolList))
+	p.allowedProtocolsRegexLink = regexp.MustCompile(wordListToRegex(p.getConfiguration().AllowedProtocolListLink))
 
 	t.Run("link protocol matches allowed protocol list", func(t *testing.T) {
 		in := &model.Post{


### PR DESCRIPTION
#### Summary
The PR is for dancing-penguin. The suggested update will split the Allowed Protocol list into two lists. One list to be maintained for formatted links, the other for plain-text links.