### PR TITLE
fix: use optional double slash matching for both embedded and plain text links

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -28,12 +28,13 @@ type Plugin struct {
 const (
 	// Following regex would match links embedded with texts in markdown
 	// e.g. [test](https://www.github.com)
-	EmbeddedLinkRegexString = `\[(?P<text>.*?)\]\((?P<protocol>\w+):(?P<host>[^\n)]+)?\)`
+	EmbeddedLinkRegexString = `\[(?P<text>.*?)\]\((?P<protocol>\w+):[//]?(?P<host>[^\n)]+)?\)`
 
 	// Following regex would match links
 	// e.g. https://github.com
-	PlainLinkRegexString = `(?P<protocol>\w+)://(?P<host>[^\n)]+)?`
+	PlainLinkRegexString = `(?P<protocol>\w+):[//]?(?P<host>[^\n)]+)?`
 
+	// Message to be displayed when a post is rejected
 	InvalidURLSchemeMessage = "\nFollowing URL Scheme is not allowed: `%s`"
 )
 

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,79 +9,78 @@ import (
 )
 
 func TestGetInvalidURLsWithPlainLinks(t *testing.T) {
-	p := Plugin{
-		configuration: &configuration{
-			RejectPlainLinks:             true,
-			AllowedProtocolListLink:      "http,https,mailto",
-			AllowedProtocolListPlainText: "http,https,mailto",
-		},
-	}
-	p.plainLinkRegex = regexp.MustCompile(PlainLinkRegexString)
-	p.embeddedLinkRegex = regexp.MustCompile(EmbeddedLinkRegexString)
-	p.allowedProtocolsRegexLink = regexp.MustCompile(wordListToRegex(p.getConfiguration().AllowedProtocolListLink))
-	p.allowedProtocolsRegexPlainText = regexp.MustCompile(wordListToRegex(p.getConfiguration().AllowedProtocolListPlainText))
+	p := newTestPlugin(true, "http,https,mailto", "http,https,mailto")
 
 	var tests = []struct {
+		name         string
 		in           *model.Post
 		expectedURLs []string
 	}{
 		{
+			name: "allowed embedded links are allowed",
 			in: &model.Post{
 				Message: "[test](https://www.github.com)",
 			},
 			expectedURLs: []string{},
 		},
 		{
+			name: "non-allowed embedded links are rejected",
 			in: &model.Post{
 				Message: "[test](s3://www.github.com)",
 			},
 			expectedURLs: []string{"s3"},
 		},
 		{
+			name: "non-allowed embedded links are rejected with multiple embedded links",
 			in: &model.Post{
 				Message: "[test](s3://www.github.com) [test](s4://www.github.com) [test](s3://www.github.com)",
 			},
 			expectedURLs: []string{"s3", "s4"},
 		},
 		{
+			name: "non-allowed embedded links are rejected with multiple links and plain links",
 			in: &model.Post{
 				Message: "s3://www.github.com [test](s4://www.github.com)",
 			},
 			expectedURLs: []string{"s3", "s4"},
 		},
 		{
+			name: "non-allowed embedded links are rejected with multiple links and plain links",
 			in: &model.Post{
 				Message: "https://www.github.com [test](s3://www.github.com)",
 			},
 			expectedURLs: []string{"s3"},
 		},
-		// Check that disallowed schemes are detected in both embedded and plain links
 		{
+			name: "non-allowed plain with double slashes links are rejected",
 			in: &model.Post{
 				Message: "tel://999999999",
 			},
 			expectedURLs: []string{"tel"},
 		},
 		{
+			name: "non-allowed plain without double slashes links are rejected",
 			in: &model.Post{
 				Message: "tel:999999999",
 			},
 			expectedURLs: []string{"tel"},
 		},
 		{
+			name: "non-allowed embedded links without double slashes are rejected",
 			in: &model.Post{
 				Message: "[+999999999](tel:+999999999)",
 			},
 			expectedURLs: []string{"tel"},
 		},
-		// Check that allowed schemes are not detected with and without double slashes
 		{
+			name: "allowed embedded links without double slashes are allowed",
 			in: &model.Post{
 				Message: "[plugin@example.com](mailto:plugin@example.com)",
 			},
 			expectedURLs: []string{},
 		},
 		{
+			name: "allowed embedded links with double slashes are allowed",
 			in: &model.Post{
 				Message: "[plugin@example.com](mailto://plugin@example.com)",
 			},
@@ -91,7 +89,7 @@ func TestGetInvalidURLsWithPlainLinks(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		t.Run(test.in.Message, func(t *testing.T) {
+		t.Run(test.name, func(t *testing.T) {
 			invalidURLs := p.getInvalidURLs(test.in)
 			assert.ElementsMatch(t, test.expectedURLs, invalidURLs)
 		})
@@ -99,47 +97,43 @@ func TestGetInvalidURLsWithPlainLinks(t *testing.T) {
 }
 
 func TestGetInvalidURLsWithoutPlainLinks(t *testing.T) {
-	p := Plugin{
-		configuration: &configuration{
-			RejectPlainLinks:             false,
-			AllowedProtocolListLink:      "http,https,mailto",
-			AllowedProtocolListPlainText: "http,https,mailto",
-		},
-	}
-	p.plainLinkRegex = regexp.MustCompile(PlainLinkRegexString)
-	p.embeddedLinkRegex = regexp.MustCompile(EmbeddedLinkRegexString)
-	p.allowedProtocolsRegexLink = regexp.MustCompile(wordListToRegex(p.getConfiguration().AllowedProtocolListLink))
-	p.allowedProtocolsRegexPlainText = regexp.MustCompile(wordListToRegex(p.getConfiguration().AllowedProtocolListPlainText))
+	p := newTestPlugin(false, "http,https,mailto", "http,https,mailto")
 
 	var tests = []struct {
+		name         string
 		in           *model.Post
 		expectedURLs []string
 	}{
 		{
+			name: "allows plain link with double slashes",
 			in: &model.Post{
 				Message: "tel://999999999",
 			},
 			expectedURLs: []string{},
 		},
 		{
+			name: "allows plain link without double slashes",
 			in: &model.Post{
 				Message: "tel:999999999",
 			},
 			expectedURLs: []string{},
 		},
 		{
+			name: "allows embedded link without double slashes",
 			in: &model.Post{
 				Message: "[+999999999](tel:+999999999)",
 			},
 			expectedURLs: []string{"tel"},
 		},
 		{
+			name: "allows embedded link without double slashes",
 			in: &model.Post{
 				Message: "[plugin@example.com](mailto:plugin@example.com)",
 			},
 			expectedURLs: []string{},
 		},
 		{
+			name: "allows embedded link with double slashes",
 			in: &model.Post{
 				Message: "[plugin@example.com](mailto://plugin@example.com)",
 			},
@@ -148,7 +142,7 @@ func TestGetInvalidURLsWithoutPlainLinks(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		t.Run(test.in.Message, func(t *testing.T) {
+		t.Run(test.name, func(t *testing.T) {
 			invalidURLs := p.getInvalidURLs(test.in)
 			assert.ElementsMatch(t, test.expectedURLs, invalidURLs)
 		})


### PR DESCRIPTION
#### Summary
This Pull Request addresses a problem with the URL matching of the plugin. Currently the plain text links are matched using fixed double slash after the semicolon (`://`) while the embedded links do not. I have added an optional group for the slashes for both regex and some test cases to ensure the matching works as expected.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49253

