### PR TITLE
feat: Perform changes related to CI/CD. Prepare plugin for community migration.

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,5 +6,5 @@ on:
 
 jobs:
   plugin-cd:
-    uses: mattermost/actions-workflows/.github/workflows/community-plugin-cd.yml@139a051e8651e6246e3764fe342297b73120e590
+    uses: mattermost/actions-workflows/.github/workflows/community-plugin-cd.yml@d9defa3e455bdbf889573e112ad8d05b91d66b4c
     secrets: inherit

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,5 +6,5 @@ on:
 
 jobs:
   plugin-cd:
-    uses: mattermost/actions-workflows/.github/workflows/community-plugin-cd.yml@main
+    uses: mattermost/actions-workflows/.github/workflows/community-plugin-cd.yml@139a051e8651e6246e3764fe342297b73120e590
     secrets: inherit

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,7 +2,7 @@ name: cd
 on:
   push:
     tags:
-      - "^v.*"
+      - "v*"
 
 jobs:
   plugin-cd:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,18 +1,10 @@
 name: cd
 on:
-  workflow_run:
-    workflows: ["ci"]
-    branches: ["main"]
-    types:
-      - completed
   push:
     tags:
-      - "v*"
-
-permissions:
-  contents: read
+      - "^v.*"
 
 jobs:
   plugin-cd:
-    uses: mattermost/actions-workflows/.github/workflows/plugin-cd.yml@main
+    uses: mattermost/actions-workflows/.github/workflows/community-plugin-cd.yml@main
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - master
       - main
-    tags:
-      - "v*"
 
 jobs:
   plugin-ci:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
       - master
       - main
     tags:
-      - "^v.*"
+      - "v*"
 
 jobs:
   plugin-ci:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,5 +10,5 @@ on:
 
 jobs:
   plugin-ci:
-    uses: mattermost/actions-workflows/.github/workflows/community-plugin-ci.yml@main
+    uses: mattermost/actions-workflows/.github/workflows/community-plugin-ci.yml@139a051e8651e6246e3764fe342297b73120e590
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,14 @@
 name: ci
 on:
-  schedule:
-    - cron: "0 0 * * *"
+  pull_request:
   push:
     branches:
+      - master
       - main
-  pull_request:
-
-permissions:
-  contents: read
+    tags:
+      - "^v.*"
 
 jobs:
   plugin-ci:
-    uses: mattermost/actions-workflows/.github/workflows/plugin-ci.yml@main
+    uses: mattermost/actions-workflows/.github/workflows/community-plugin-ci.yml@main
     secrets: inherit


### PR DESCRIPTION
#### Summary

- Remove scheduled ci workflow and upgrade plugin-ci reusable workflow
- Do not execute ci tasks upon tag creation
- Remove cd trigger upon workflow run event. Keep it simple upon tag creation. 

#### Related PRs
https://github.com/mattermost/actions/pull/22
https://github.com/mattermost/actions-workflows/pull/40

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-7458