### PR TITLE
feat: allow rewriting of protocols

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -50,6 +50,14 @@
         "help_text": "The protocols to allow in plain text, separated by commas. Capitalization and punctuation insensitive.",
         "placeholder": "E.g., http, https, mailto, mattermost",
         "default": "http,https,mailto,mattermost"
+      },
+      {
+        "key": "RewriteProtocolList",
+        "display_name": "Rewrite Protocols List:",
+        "type": "text",
+        "help_text": "The protocols to rewrite, separated by commas. Capitalization and punctuation insensitive. Adding a protocol here will rewrite it between backticks to prevent a link from being created. Example: tel:1234 would be rewritten to `tel:1234`.",
+        "placeholder": "E.g., tel,ftp",
+        "default": ""
       }
     ],
     "header": "",

--- a/plugin.json
+++ b/plugin.json
@@ -55,7 +55,7 @@
         "key": "RewriteProtocolList",
         "display_name": "Rewrite Protocols List:",
         "type": "text",
-        "help_text": "The protocols to rewrite, separated by commas. Capitalization and punctuation insensitive. Adding a protocol here will rewrite it between backticks to prevent a link from being created. Example: tel:1234 would be rewritten to `tel:1234`. **Protocols listed here are considered allowed for plain text links.**",
+        "help_text": "The protocols to rewrite, separated by commas. Capitalization and punctuation insensitive. Adding a protocol here will rewrite it to prevent a link from being created. Example: tel:1234 would be rewritten to tel(1234). **Protocols listed here are considered allowed for plain text links.**",
         "placeholder": "E.g., tel,ftp",
         "default": ""
       }

--- a/plugin.json
+++ b/plugin.json
@@ -55,7 +55,7 @@
         "key": "RewriteProtocolList",
         "display_name": "Rewrite Protocols List:",
         "type": "text",
-        "help_text": "The protocols to rewrite, separated by commas. Capitalization and punctuation insensitive. Adding a protocol here will rewrite it between backticks to prevent a link from being created. Example: tel:1234 would be rewritten to `tel:1234`.",
+        "help_text": "The protocols to rewrite, separated by commas. Capitalization and punctuation insensitive. Adding a protocol here will rewrite it between backticks to prevent a link from being created. Example: tel:1234 would be rewritten to `tel:1234`. **Protocols listed here are considered allowed for plain text links.**",
         "placeholder": "E.g., tel,ftp",
         "default": ""
       }

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -110,7 +110,9 @@ func (p *Plugin) initConfiguration(configuration *configuration) error {
 	}
 	p.allowedProtocolsRegexPlainText = regexPlainText
 
-	p.rewriteProtocolList = strings.Split(configuration.RewriteProtocolList, ",")
+	for _, scheme := range strings.Split(configuration.RewriteProtocolList, ",") {
+		p.rewriteProtocolList = append(p.rewriteProtocolList, strings.TrimSpace(scheme))
+	}
 
 	return nil
 }

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -90,6 +90,10 @@ func (p *Plugin) OnConfigurationChange() error {
 
 	p.setConfiguration(configuration)
 
+	return p.initConfiguration(configuration)
+}
+
+func (p *Plugin) initConfiguration(configuration *configuration) error {
 	// Addind space around the words (Link)
 	regexStringLink := wordListToRegex(configuration.AllowedProtocolListLink)
 	regexLink, err := regexp.Compile(regexStringLink)

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -28,6 +28,7 @@ type configuration struct {
 	AllowedProtocolListPlainText string
 	CreatePostWarningMessage     string
 	EditPostWarningMessage       string
+	RewriteProtocolList          string
 }
 
 // Clone shallow copies the configuration. Your implementation may require a deep copy if
@@ -104,6 +105,8 @@ func (p *Plugin) OnConfigurationChange() error {
 		return err
 	}
 	p.allowedProtocolsRegexPlainText = regexPlainText
+
+	p.rewriteProtocolList = strings.Split(configuration.RewriteProtocolList, ",")
 
 	return nil
 }

--- a/server/configuration_test.go
+++ b/server/configuration_test.go
@@ -1,34 +1,16 @@
 package main
 
 import (
-	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func newTestPlugin(rejectPlainLinks bool, allowedProtocolList, allowedProtocolListPlainText, rewriteProtocolList string) *Plugin {
-	p := Plugin{
-		configuration: &configuration{
-			RejectPlainLinks:             rejectPlainLinks,
-			AllowedProtocolListLink:      allowedProtocolList,
-			AllowedProtocolListPlainText: allowedProtocolListPlainText,
-			RewriteProtocolList:          rewriteProtocolList,
-		},
-	}
-	p.plainLinkRegex = regexp.MustCompile(PlainLinkRegexString)
-	p.embeddedLinkRegex = regexp.MustCompile(EmbeddedLinkRegexString)
-	p.allowedProtocolsRegexLink = regexp.MustCompile(wordListToRegex(p.getConfiguration().AllowedProtocolListLink))
-	p.allowedProtocolsRegexPlainText = regexp.MustCompile(wordListToRegex(p.getConfiguration().AllowedProtocolListPlainText))
-
-	return &p
-}
-
 func TestWordListToRegex(t *testing.T) {
 	schemes := "https,http,mailto"
 	schemesWithSpaces := "https, http, mailto"
 
-	p := newTestPlugin(true, schemes, schemes, "")
+	p := newTestPlugin(t, true, schemes, schemes, "")
 
 	t.Run("Build Regex", func(t *testing.T) {
 		regexStr := wordListToRegex(p.getConfiguration().AllowedProtocolListLink)
@@ -36,7 +18,7 @@ func TestWordListToRegex(t *testing.T) {
 		assert.Equal(t, regexStr, `(?mi)\b(https|http|mailto)\b`)
 	})
 
-	p2 := newTestPlugin(true, schemesWithSpaces, schemesWithSpaces, "")
+	p2 := newTestPlugin(t, true, schemesWithSpaces, schemesWithSpaces, "")
 
 	t.Run("Build Regex with extra space", func(t *testing.T) {
 		regexStr := wordListToRegex(p2.getConfiguration().AllowedProtocolListLink)

--- a/server/configuration_test.go
+++ b/server/configuration_test.go
@@ -7,12 +7,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func newTestPlugin(rejectPlainLinks bool, allowedProtocolList, allowedProtocolListPlainText string) *Plugin {
+func newTestPlugin(rejectPlainLinks bool, allowedProtocolList, allowedProtocolListPlainText, rewriteProtocolList string) *Plugin {
 	p := Plugin{
 		configuration: &configuration{
 			RejectPlainLinks:             rejectPlainLinks,
 			AllowedProtocolListLink:      allowedProtocolList,
 			AllowedProtocolListPlainText: allowedProtocolListPlainText,
+			RewriteProtocolList:          rewriteProtocolList,
 		},
 	}
 	p.plainLinkRegex = regexp.MustCompile(PlainLinkRegexString)
@@ -27,7 +28,7 @@ func TestWordListToRegex(t *testing.T) {
 	schemes := "https,http,mailto"
 	schemesWithSpaces := "https, http, mailto"
 
-	p := newTestPlugin(true, schemes, schemes)
+	p := newTestPlugin(true, schemes, schemes, "")
 
 	t.Run("Build Regex", func(t *testing.T) {
 		regexStr := wordListToRegex(p.getConfiguration().AllowedProtocolListLink)
@@ -35,7 +36,7 @@ func TestWordListToRegex(t *testing.T) {
 		assert.Equal(t, regexStr, `(?mi)\b(https|http|mailto)\b`)
 	})
 
-	p2 := newTestPlugin(true, schemesWithSpaces, schemesWithSpaces)
+	p2 := newTestPlugin(true, schemesWithSpaces, schemesWithSpaces, "")
 
 	t.Run("Build Regex with extra space", func(t *testing.T) {
 		regexStr := wordListToRegex(p2.getConfiguration().AllowedProtocolListLink)

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -104,7 +104,7 @@ func (p *Plugin) extractURLs(post *model.Post) []*detectedURL {
 
 // getInvalidProtocols returns the protocols that are not allowed in the post from the extracted URLs and the
 // plugin configuration.
-func (p *Plugin) getInvalidProtocols(detectedURLs []*detectedURL, post *model.Post) []string {
+func (p *Plugin) getInvalidProtocols(detectedURLs []*detectedURL, _ *model.Post) []string {
 	configuration := p.getConfiguration()
 
 	var invalidURLProtocols []string
@@ -178,10 +178,7 @@ func (p *Plugin) rewriteLinks(detectedURLs []*detectedURL, post *model.Post) str
 		if u.isPlainText && slices.Contains(p.rewriteProtocolList, u.protocol) {
 			detectedURLs[i].rewritten = true
 			// Trim any leading "//" from the host part
-			host := u.host
-			if strings.HasPrefix(host, "//") {
-				host = host[2:]
-			}
+			host := strings.TrimPrefix(u.host, "//")
 
 			rewritten := fmt.Sprintf("%s(%s)", u.protocol, host)
 

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -461,19 +461,12 @@ func TestFilterPost(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			mockAPI.sentEphemeralPost = nil // Reset for each test
 			detectedURLs := p.extractURLs(test.in)
-			post, errString := p.FilterPost(detectedURLs, test.in, test.isEdit)
+			errString := p.FilterPost(detectedURLs, test.in, test.isEdit)
 
 			if test.expectedPost == nil {
-				require.Nil(t, post)
 				assert.Equal(t, test.expectedError, errString)
 			} else {
 				require.Empty(t, errString)
-				assert.Equal(
-					t,
-					test.expectedPost.Message,
-					post.Message)
-				assert.Equal(t, test.expectedPost.UserId, post.UserId)
-				assert.Equal(t, test.expectedPost.ChannelId, post.ChannelId)
 			}
 
 			if test.checkEphemeral != nil {

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -1,15 +1,154 @@
 package main
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v5/plugin"
 )
 
+// Helper function to create a test plugin with the given configuration
+func newTestPlugin(t *testing.T, rejectPlainLinks bool, allowedProtocolListLink, allowedProtocolListPlainText, rewriteProtocolList string) *Plugin {
+	p := &Plugin{}
+	p.configuration = &configuration{
+		RejectPlainLinks:             rejectPlainLinks,
+		AllowedProtocolListLink:      allowedProtocolListLink,
+		AllowedProtocolListPlainText: allowedProtocolListPlainText,
+		RewriteProtocolList:          rewriteProtocolList,
+		CreatePostWarningMessage:     "Your post has been rejected by the Link Filter.",
+		EditPostWarningMessage:       "Your edit has been rejected by the Link Filter.",
+	}
+
+	// Initialize regex patterns
+	p.initRegexes()
+	require.NoError(t, p.initConfiguration(p.configuration))
+
+	return p
+}
+
+// TestExtractURLs tests the extractURLs method
+func TestExtractURLs(t *testing.T) {
+	// Test with empty allowed protocols since that shouldn't matter for the URL extraction
+	p := newTestPlugin(t, true, "", "", "")
+
+	var tests = []struct {
+		name          string
+		in            *model.Post
+		expectedCount int
+		expectedURLs  []*detectedURL
+	}{
+		{
+			name: "extracts embedded link",
+			in: &model.Post{
+				Message: "[test](https://www.github.com)",
+			},
+			expectedCount: 1,
+			expectedURLs: []*detectedURL{
+				{
+					protocol:     "https",
+					host:         "www.github.com",
+					originalText: "[test](https://www.github.com)",
+					isPlainText:  false,
+				},
+			},
+		},
+		{
+			name: "extracts plain link",
+			in: &model.Post{
+				Message: "https://www.github.com",
+			},
+			expectedCount: 1,
+			expectedURLs: []*detectedURL{
+				{
+					protocol:     "https",
+					host:         "www.github.com",
+					originalText: "https://www.github.com",
+					isPlainText:  true,
+				},
+			},
+		},
+		{
+			name: "extracts multiple links",
+			in: &model.Post{
+				Message: "[test](s3://www.github.com) https://www.github.com",
+			},
+			expectedCount: 2,
+			expectedURLs: []*detectedURL{
+				{
+					protocol:     "s3",
+					host:         "www.github.com",
+					originalText: "[test](s3://www.github.com)",
+					isPlainText:  false,
+				},
+				{
+					protocol:     "https",
+					host:         "www.github.com",
+					originalText: "https://www.github.com",
+					isPlainText:  true,
+				},
+			},
+		},
+		{
+			name: "extracts mailto link",
+			in: &model.Post{
+				Message: "[plugin@example.com](mailto:plugin@example.com)",
+			},
+			expectedCount: 1,
+			expectedURLs: []*detectedURL{
+				{
+					protocol:     "mailto",
+					host:         "plugin@example.com",
+					originalText: "[plugin@example.com](mailto:plugin@example.com)",
+					isPlainText:  false,
+				},
+			},
+		},
+		{
+			name: "extracts tel link",
+			in: &model.Post{
+				Message: "tel://999999999",
+			},
+			expectedCount: 1,
+			expectedURLs: []*detectedURL{
+				{
+					protocol:     "tel",
+					host:         "999999999",
+					originalText: "tel://999999999",
+					isPlainText:  true,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			detectedURLs := p.extractURLs(test.in)
+			assert.Equal(t, test.expectedCount, len(detectedURLs))
+			// Compare the extracted URLs with the expected URLs. Mind that the order of the URLs is not guaranteed.
+			for _, expectedURL := range test.expectedURLs {
+				found := false
+				for _, detectedURL := range detectedURLs {
+					if expectedURL.originalText == detectedURL.originalText {
+						// Ensure that we extracted the URL correctly
+						require.Equal(t, expectedURL.protocol, detectedURL.protocol, "Protocol mismatch for %s", expectedURL.originalText)
+						require.Equal(t, expectedURL.host, detectedURL.host, "Host mismatch for %s", expectedURL.originalText)
+						require.Equal(t, expectedURL.isPlainText, detectedURL.isPlainText, "isPlainText mismatch for %s", expectedURL.originalText)
+						found = true
+						break
+					}
+				}
+				assert.True(t, found, "%s not found in detected URLs", expectedURL.originalText)
+			}
+		})
+	}
+}
+
 func TestGetInvalidURLsWithPlainLinks(t *testing.T) {
-	p := newTestPlugin(true, "http,https,mailto", "http,https,mailto", "")
+	p := newTestPlugin(t, true, "http,https,mailto", "http,https,mailto", "")
 
 	var tests = []struct {
 		name         string
@@ -91,62 +230,554 @@ func TestGetInvalidURLsWithPlainLinks(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			detectedURLs := p.extractURLs(test.in)
-			invalidURLs := p.getInvalidURLs(detectedURLs, test.in)
+			invalidURLs := p.getInvalidProtocols(detectedURLs, test.in)
 			assert.ElementsMatch(t, test.expectedURLs, invalidURLs)
 		})
 	}
 }
 
-func TestGetInvalidURLsWithoutPlainLinks(t *testing.T) {
-	p := newTestPlugin(false, "http,https,mailto", "http,https,mailto", "")
+func TestGetInvalidURLsWithRewriteProtocols(t *testing.T) {
+	p := newTestPlugin(t, true, "http,https,mailto", "http,https,mailto", "tel,ftp")
 
 	var tests = []struct {
-		name         string
-		in           *model.Post
-		expectedURLs []string
+		name             string
+		in               *model.Post
+		invalidProtocols []string
 	}{
 		{
-			name: "allows plain link with double slashes",
+			name: "allows tel protocol in plain link due to rewrite list",
 			in: &model.Post{
 				Message: "tel://999999999",
 			},
-			expectedURLs: []string{},
+			invalidProtocols: []string{},
 		},
 		{
-			name: "allows plain link without double slashes",
+			name: "rejects tel protocol in embedded link",
 			in: &model.Post{
-				Message: "tel:999999999",
+				Message: "[test](tel://999999999)",
 			},
-			expectedURLs: []string{},
+			invalidProtocols: []string{"tel"},
 		},
 		{
-			name: "allows embedded link without double slashes",
+			name: "allows ftp protocol in plain link due to rewrite list",
 			in: &model.Post{
-				Message: "[+999999999](tel:+999999999)",
+				Message: "ftp://example.com",
 			},
-			expectedURLs: []string{"tel"},
+			invalidProtocols: []string{},
 		},
 		{
-			name: "allows embedded link without double slashes",
+			name: "rejects tel in embedded link but allows tel in plain text",
 			in: &model.Post{
-				Message: "[plugin@example.com](mailto:plugin@example.com)",
+				Message: "tel:123456 [test](tel://999)",
 			},
-			expectedURLs: []string{},
+			invalidProtocols: []string{"tel"},
 		},
 		{
-			name: "allows embedded link with double slashes",
+			name: "reject rewriten protocol in markdown link",
 			in: &model.Post{
-				Message: "[plugin@example.com](mailto://plugin@example.com)",
+				Message: "ftp://example.com [test](tel://999999999)",
 			},
-			expectedURLs: []string{},
+			invalidProtocols: []string{"tel"},
+		},
+		{
+			name: "rejects unlisted protocol in markdown link",
+			in: &model.Post{
+				Message: "sftp://example.com",
+			},
+			invalidProtocols: []string{"sftp"},
+		},
+		{
+			name: "reject unlisted protocol in plain link",
+			in: &model.Post{
+				Message: "aria2://999999999",
+			},
+			invalidProtocols: []string{"aria2"},
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			detectedURLs := p.extractURLs(test.in)
-			invalidURLs := p.getInvalidURLs(detectedURLs, test.in)
-			assert.ElementsMatch(t, test.expectedURLs, invalidURLs)
+			_ = p.rewriteLinks(detectedURLs, test.in)
+			invalidProtocols := p.getInvalidProtocols(detectedURLs, test.in)
+			assert.ElementsMatch(t, test.invalidProtocols, invalidProtocols)
 		})
 	}
+}
+
+// TestRewriteLinks tests the rewriteLinks method
+func TestRewriteLinks(t *testing.T) {
+	p := newTestPlugin(t, true, "http,https,mailto", "http,https,mailto", "tel,ftp")
+
+	t.Run("rewritting a link marks it as rewritten", func(t *testing.T) {
+		detectedURLs := p.extractURLs(&model.Post{
+			Message: "tel://999999999",
+		})
+		rewrittenMessage := p.rewriteLinks(detectedURLs, &model.Post{
+			Message: "tel://999999999",
+		})
+		assert.Equal(t, "`tel://999999999`", rewrittenMessage)
+		assert.True(t, detectedURLs[0].rewritten)
+	})
+
+	t.Run("test rewriting", func(t *testing.T) {
+		var tests = []struct {
+			name           string
+			in             *model.Post
+			expectedOutput string
+		}{
+			{
+				name: "rewrites tel protocol in plain link",
+				in: &model.Post{
+					Message: "tel://999999999",
+				},
+				expectedOutput: "`tel://999999999`",
+			},
+			{
+				name: "rewrites ftp protocol in plain link",
+				in: &model.Post{
+					Message: "ftp://example.com",
+				},
+				expectedOutput: "`ftp://example.com`",
+			},
+			{
+				name: "rewrites multiple protocols in mixed content",
+				in: &model.Post{
+					Message: "tel:123456 [test](ftp://example.com) [test2](tel://999)",
+				},
+				expectedOutput: "`tel:123456` [test](ftp://example.com) [test2](tel://999)",
+			},
+			{
+				name: "doesn't rewrite non-listed protocols",
+				in: &model.Post{
+					Message: "sftp://example.com",
+				},
+				expectedOutput: "sftp://example.com",
+			},
+			{
+				name: "rewrites multiple occurrences of the same protocol",
+				in: &model.Post{
+					Message: "tel:123456 tel:789012",
+				},
+				expectedOutput: "`tel:123456` `tel:789012`",
+			},
+			{
+				name: "multiple occurrences of the same protocol and value",
+				in: &model.Post{
+					Message: "tel:123456 tel:789012 tel:123456",
+				},
+				expectedOutput: "`tel:123456` `tel:789012` `tel:123456`",
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				detectedURLs := p.extractURLs(test.in)
+				rewrittenMessage := p.rewriteLinks(detectedURLs, test.in)
+				assert.Equal(t, test.expectedOutput, rewrittenMessage)
+			})
+		}
+	})
+}
+
+// Mock API implementation
+type mockAPI struct {
+	plugin.API
+	sentEphemeralPost *model.Post
+}
+
+func (m *mockAPI) SendEphemeralPost(_ string, post *model.Post) *model.Post {
+	m.sentEphemeralPost = post
+	return post
+}
+
+// TestFilterPost tests the FilterPost method
+func TestFilterPost(t *testing.T) {
+	p := newTestPlugin(t, true, "http,https,mailto", "http,https,mailto", "tel")
+	mockAPI := &mockAPI{}
+	p.API = mockAPI
+
+	var tests = []struct {
+		name           string
+		in             *model.Post
+		isEdit         bool
+		expectedPost   *model.Post
+		expectedError  string
+		checkEphemeral func(*testing.T, *model.Post)
+	}{
+		{
+			name: "allows valid post",
+			in: &model.Post{
+				Message:   "[test](https://www.github.com)",
+				UserId:    "user1",
+				ChannelId: "channel1",
+			},
+			isEdit: false,
+			expectedPost: &model.Post{
+				Message:   "[test](https://www.github.com)",
+				UserId:    "user1",
+				ChannelId: "channel1",
+			},
+			expectedError: "",
+			checkEphemeral: func(t *testing.T, p *model.Post) {
+				assert.Nil(t, p, "No ephemeral post should be sent for valid posts")
+			},
+		},
+		{
+			name: "rejects post with invalid protocol",
+			in: &model.Post{
+				Message:   "[test](s3://www.github.com)",
+				UserId:    "user1",
+				ChannelId: "channel1",
+			},
+			isEdit:        false,
+			expectedPost:  nil,
+			expectedError: "Schemes not allowed: s3",
+			checkEphemeral: func(t *testing.T, p *model.Post) {
+				assert.NotNil(t, p, "Ephemeral post should be sent for invalid posts")
+				assert.Equal(t, "channel1", p.ChannelId)
+				assert.Contains(t, p.Message, "s3")
+			},
+		},
+		{
+			name: "rejects edit with invalid protocol",
+			in: &model.Post{
+				Message:   "[test](s3://www.github.com)",
+				UserId:    "user1",
+				ChannelId: "channel1",
+			},
+			isEdit:        true,
+			expectedPost:  nil,
+			expectedError: "Schemes not allowed: s3",
+			checkEphemeral: func(t *testing.T, p *model.Post) {
+				assert.NotNil(t, p, "Ephemeral post should be sent for invalid edits")
+				assert.Equal(t, "channel1", p.ChannelId)
+				assert.Contains(t, p.Message, "s3")
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mockAPI.sentEphemeralPost = nil // Reset for each test
+			detectedURLs := p.extractURLs(test.in)
+			post, errString := p.FilterPost(detectedURLs, test.in, test.isEdit)
+
+			if test.expectedPost == nil {
+				require.Nil(t, post)
+				assert.Equal(t, test.expectedError, errString)
+			} else {
+				require.Empty(t, errString)
+				assert.Equal(
+					t,
+					test.expectedPost.Message,
+					post.Message)
+				assert.Equal(t, test.expectedPost.UserId, post.UserId)
+				assert.Equal(t, test.expectedPost.ChannelId, post.ChannelId)
+			}
+
+			if test.checkEphemeral != nil {
+				test.checkEphemeral(t, mockAPI.sentEphemeralPost)
+			}
+		})
+	}
+}
+
+// TestRegexPatterns tests the regex patterns directly
+func TestRegexPatterns(t *testing.T) {
+	embeddedRegex := regexp.MustCompile(EmbeddedLinkRegexString)
+	plainRegex := regexp.MustCompile(PlainLinkRegexString)
+
+	tests := []struct {
+		name         string
+		input        string
+		regex        *regexp.Regexp
+		expectMatch  bool
+		expectGroups map[string]string
+	}{
+		{
+			name:        "embedded link with https",
+			input:       "[test](https://www.github.com)",
+			regex:       embeddedRegex,
+			expectMatch: true,
+			expectGroups: map[string]string{
+				"text":     "test",
+				"protocol": "https",
+				"host":     "www.github.com",
+			},
+		},
+		{
+			name:        "embedded link with s3",
+			input:       "[test](s3://bucket.name)",
+			regex:       embeddedRegex,
+			expectMatch: true,
+			expectGroups: map[string]string{
+				"text":     "test",
+				"protocol": "s3",
+				"host":     "bucket.name",
+			},
+		},
+		{
+			name:        "plain link with https",
+			input:       "https://www.github.com",
+			regex:       plainRegex,
+			expectMatch: true,
+			expectGroups: map[string]string{
+				"protocol": "https",
+				"host":     "www.github.com",
+			},
+		},
+		{
+			name:        "plain link with tel",
+			input:       "tel:999999999",
+			regex:       plainRegex,
+			expectMatch: true,
+			expectGroups: map[string]string{
+				"protocol": "tel",
+				"host":     "999999999",
+			},
+		},
+		{
+			name:        "plain link with mailto",
+			input:       "mailto:user@example.com",
+			regex:       plainRegex,
+			expectMatch: true,
+			expectGroups: map[string]string{
+				"protocol": "mailto",
+				"host":     "user@example.com",
+			},
+		},
+		{
+			name:         "Message with semicolons",
+			input:        "this is a link: or not",
+			regex:        plainRegex,
+			expectMatch:  false,
+			expectGroups: map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matches := tt.regex.FindStringSubmatch(tt.input)
+			if tt.expectMatch {
+				require.NotNil(t, matches, "Expected input to match regex but it didn't")
+
+				// Get the named capture group indices
+				namedGroups := tt.regex.SubexpNames()
+
+				// Check each expected group
+				for groupName, expectedValue := range tt.expectGroups {
+					// Find the index of the named group
+					groupIdx := -1
+					for i, name := range namedGroups {
+						if name == groupName {
+							groupIdx = i
+							break
+						}
+					}
+					require.NotEqual(t, -1, groupIdx, "Named group %s not found in regex", groupName)
+					require.Equal(t, expectedValue, matches[groupIdx],
+						"Mismatch in group %s. Expected: %s, Got: %s",
+						groupName, expectedValue, matches[groupIdx])
+				}
+			} else {
+				require.Nil(t, matches, "Expected input not to match regex but it did")
+			}
+		})
+	}
+}
+
+// TestMessageHooks tests the MessageWillBePosted and MessageWillBeUpdated methods
+func TestMessageHooks(t *testing.T) {
+	// Create a plugin with configuration that allows http, https, mailto protocols
+	// and rewrites tel and ftp protocols
+	p := newTestPlugin(t, true, "http,https,mailto,aria2", "http,https,mailto,aria2", "tel,ftp")
+	mockAPI := &mockAPI{}
+	p.API = mockAPI
+
+	// Test cases for both MessageWillBePosted and MessageWillBeUpdated
+	testCases := []struct {
+		name           string
+		post           *model.Post
+		oldPost        *model.Post // Only used for MessageWillBeUpdated
+		expectedPost   *model.Post
+		expectedError  string
+		checkEphemeral func(*testing.T, *model.Post)
+	}{
+		{
+			name: "allows valid post with http link",
+			post: &model.Post{
+				Message:   "Check this link: https://www.github.com",
+				UserId:    "user1",
+				ChannelId: "channel1",
+			},
+			expectedPost: &model.Post{
+				Message:   "Check this link: https://www.github.com",
+				UserId:    "user1",
+				ChannelId: "channel1",
+			},
+			expectedError: "",
+			checkEphemeral: func(t *testing.T, p *model.Post) {
+				assert.Nil(t, p, "No ephemeral post should be sent for valid posts")
+			},
+		},
+		{
+			name: "allows valid post with embedded link",
+			post: &model.Post{
+				Message:   "Check this [link](https://www.github.com)",
+				UserId:    "user1",
+				ChannelId: "channel1",
+			},
+			expectedPost: &model.Post{
+				Message:   "Check this [link](https://www.github.com)",
+				UserId:    "user1",
+				ChannelId: "channel1",
+			},
+			expectedError: "",
+			checkEphemeral: func(t *testing.T, p *model.Post) {
+				assert.Nil(t, p, "No ephemeral post should be sent for valid posts")
+			},
+		},
+		{
+			name: "rejects post with invalid protocol",
+			post: &model.Post{
+				Message:   "Check this [link](s3://bucket.name)",
+				UserId:    "user1",
+				ChannelId: "channel1",
+			},
+			expectedPost:  nil,
+			expectedError: "Schemes not allowed: s3",
+			checkEphemeral: func(t *testing.T, p *model.Post) {
+				assert.NotNil(t, p, "Ephemeral post should be sent for invalid posts")
+				assert.Equal(t, "channel1", p.ChannelId)
+				assert.Contains(t, p.Message, "s3")
+			},
+		},
+		{
+			name: "rewrites tel protocol in plain link",
+			post: &model.Post{
+				Message:   "Call me at tel://1234567890",
+				UserId:    "user1",
+				ChannelId: "channel1",
+			},
+			expectedPost: &model.Post{
+				Message:   "Call me at `tel://1234567890`",
+				UserId:    "user1",
+				ChannelId: "channel1",
+			},
+			expectedError: "",
+			checkEphemeral: func(t *testing.T, p *model.Post) {
+				assert.Nil(t, p, "No ephemeral post should be sent for rewritten posts")
+			},
+		},
+		{
+			name: "rewrites ftp protocol in plain link",
+			post: &model.Post{
+				Message:   "Download from ftp://example.com/file.txt",
+				UserId:    "user1",
+				ChannelId: "channel1",
+			},
+			expectedPost: &model.Post{
+				Message:   "Download from `ftp://example.com/file.txt`",
+				UserId:    "user1",
+				ChannelId: "channel1",
+			},
+			expectedError: "",
+			checkEphemeral: func(t *testing.T, p *model.Post) {
+				assert.Nil(t, p, "No ephemeral post should be sent for rewritten posts")
+			},
+		},
+		{
+			name: "rewrites multiple protocols in mixed content",
+			post: &model.Post{
+				Message:   "tel:123456 [test](https://example.com) [test2](aria2://999) ftp://example.com",
+				UserId:    "user1",
+				ChannelId: "channel1",
+			},
+			expectedPost: &model.Post{
+				Message:   "`tel:123456` [test](https://example.com) [test2](aria2://999) `ftp://example.com`",
+				UserId:    "user1",
+				ChannelId: "channel1",
+			},
+			expectedError: "",
+			checkEphemeral: func(t *testing.T, p *model.Post) {
+				assert.Nil(t, p, "No ephemeral post should be sent for rewritten posts")
+			},
+		},
+	}
+
+	// Test MessageWillBePosted
+	t.Run("MessageWillBePosted", func(t *testing.T) {
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				mockAPI.sentEphemeralPost = nil // Reset for each test
+
+				// Create a copy of the post to avoid modifying the original
+				postCopy := &model.Post{
+					Message:   tc.post.Message,
+					UserId:    tc.post.UserId,
+					ChannelId: tc.post.ChannelId,
+				}
+
+				// Call MessageWillBePosted
+				resultPost, errString := p.MessageWillBePosted(nil, postCopy)
+
+				// Check results
+				if tc.expectedPost == nil {
+					require.Nil(t, resultPost)
+					assert.Equal(t, tc.expectedError, errString)
+				} else {
+					require.Empty(t, errString)
+					assert.Equal(t, tc.expectedPost.Message, resultPost.Message)
+					assert.Equal(t, tc.expectedPost.UserId, resultPost.UserId)
+					assert.Equal(t, tc.expectedPost.ChannelId, resultPost.ChannelId)
+				}
+
+				if tc.checkEphemeral != nil {
+					tc.checkEphemeral(t, mockAPI.sentEphemeralPost)
+				}
+			})
+		}
+	})
+
+	// Test MessageWillBeUpdated
+	t.Run("MessageWillBeUpdated", func(t *testing.T) {
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				mockAPI.sentEphemeralPost = nil // Reset for each test
+
+				// Create a copy of the post to avoid modifying the original
+				postCopy := &model.Post{
+					Message:   tc.post.Message,
+					UserId:    tc.post.UserId,
+					ChannelId: tc.post.ChannelId,
+				}
+
+				// Create an old post (can be empty for these tests)
+				oldPost := &model.Post{
+					Message:   "Old message",
+					UserId:    tc.post.UserId,
+					ChannelId: tc.post.ChannelId,
+				}
+
+				// Call MessageWillBeUpdated
+				resultPost, errString := p.MessageWillBeUpdated(nil, postCopy, oldPost)
+
+				// Check results
+				if tc.expectedPost == nil {
+					require.Nil(t, resultPost)
+					assert.Equal(t, tc.expectedError, errString)
+				} else {
+					require.Empty(t, errString)
+					assert.Equal(t, tc.expectedPost.Message, resultPost.Message)
+					assert.Equal(t, tc.expectedPost.UserId, resultPost.UserId)
+					assert.Equal(t, tc.expectedPost.ChannelId, resultPost.ChannelId)
+				}
+
+				if tc.checkEphemeral != nil {
+					tc.checkEphemeral(t, mockAPI.sentEphemeralPost)
+				}
+			})
+		}
+	})
 }

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestGetInvalidURLsWithPlainLinks(t *testing.T) {
-	p := newTestPlugin(true, "http,https,mailto", "http,https,mailto")
+	p := newTestPlugin(true, "http,https,mailto", "http,https,mailto", "")
 
 	var tests = []struct {
 		name         string
@@ -90,14 +90,15 @@ func TestGetInvalidURLsWithPlainLinks(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			invalidURLs := p.getInvalidURLs(test.in)
+			detectedURLs := p.extractURLs(test.in)
+			invalidURLs := p.getInvalidURLs(detectedURLs, test.in)
 			assert.ElementsMatch(t, test.expectedURLs, invalidURLs)
 		})
 	}
 }
 
 func TestGetInvalidURLsWithoutPlainLinks(t *testing.T) {
-	p := newTestPlugin(false, "http,https,mailto", "http,https,mailto")
+	p := newTestPlugin(false, "http,https,mailto", "http,https,mailto", "")
 
 	var tests = []struct {
 		name         string
@@ -143,7 +144,8 @@ func TestGetInvalidURLsWithoutPlainLinks(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			invalidURLs := p.getInvalidURLs(test.in)
+			detectedURLs := p.extractURLs(test.in)
+			invalidURLs := p.getInvalidURLs(detectedURLs, test.in)
 			assert.ElementsMatch(t, test.expectedURLs, invalidURLs)
 		})
 	}

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -649,12 +649,12 @@ func TestMessageHooks(t *testing.T) {
 		{
 			name: "rewrites tel protocol in plain link",
 			post: &model.Post{
-				Message:   "Call me at tel://1234567890",
+				Message:   "Call me at tel://1234567890, please",
 				UserId:    "user1",
 				ChannelId: "channel1",
 			},
 			expectedPost: &model.Post{
-				Message:   "Call me at `tel://1234567890`",
+				Message:   "Call me at `tel://1234567890`, please",
 				UserId:    "user1",
 				ChannelId: "channel1",
 			},
@@ -689,6 +689,57 @@ func TestMessageHooks(t *testing.T) {
 			},
 			expectedPost: &model.Post{
 				Message:   "`tel:123456` [test](https://example.com) [test2](aria2://999) `ftp://example.com`",
+				UserId:    "user1",
+				ChannelId: "channel1",
+			},
+			expectedError: "",
+			checkEphemeral: func(t *testing.T, p *model.Post) {
+				assert.Nil(t, p, "No ephemeral post should be sent for rewritten posts")
+			},
+		},
+		{
+			name: "link with single backtick",
+			post: &model.Post{
+				Message:   "tel:123456`",
+				UserId:    "user1",
+				ChannelId: "channel1",
+			},
+			expectedPost: &model.Post{
+				Message:   "`tel:123456`",
+				UserId:    "user1",
+				ChannelId: "channel1",
+			},
+			expectedError: "",
+			checkEphemeral: func(t *testing.T, p *model.Post) {
+				assert.Nil(t, p, "No ephemeral post should be sent for rewritten posts")
+			},
+		},
+		{
+			name: "link with single backtick",
+			post: &model.Post{
+				Message:   "`tel:123456",
+				UserId:    "user1",
+				ChannelId: "channel1",
+			},
+			expectedPost: &model.Post{
+				Message:   "`tel:123456`",
+				UserId:    "user1",
+				ChannelId: "channel1",
+			},
+			expectedError: "",
+			checkEphemeral: func(t *testing.T, p *model.Post) {
+				assert.Nil(t, p, "No ephemeral post should be sent for rewritten posts")
+			},
+		},
+		{
+			name: "link with backticks",
+			post: &model.Post{
+				Message:   "`tel:123456`",
+				UserId:    "user1",
+				ChannelId: "channel1",
+			},
+			expectedPost: &model.Post{
+				Message:   "`tel:123456`",
 				UserId:    "user1",
 				ChannelId: "channel1",
 			},

--- a/server/util/util.go
+++ b/server/util/util.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 )
 
+// TrimString removes empty spaces from all strings in a slice of strings.
 func TrimString(textList []string) []string {
 	var r []string
 	for _, str := range textList {


### PR DESCRIPTION
## Summary

This pull request introduces a new feature to rewrite specific protocols in messages to a `scheme(host)` format to prevent the autolinking from formatting those.

- Refactored the initialization logic to different function to make tests easier to handle
- Refactored the data flow to have: 1) function to extract URLs, 2) function to rewrite urls and 3) function to filter posts. This made the code way easier to test and allows working with a single call to the URL extraction.

## Test cases 

There are three settings: 1) reject embedded (markdown) link schemes 2) reject plain text schemes and 3) rewrite schemes

This change adds the third option, which ignores the previous settings and will find any **plain text link** with the schemes set in the configuration and enclose them in backticks (example: [tel://1111](#fakelink) would be tel(1111)).

Test out different combinations keeping in mind that rewriting a scheme takes priority over the rest of the configuration: if you reject plain text `tel` and rewrite `tel`, the link will be reformatted and **not** rejected.

## Copilot summary

This pull request introduces a new feature to rewrite specific protocols in plain text links and includes significant refactoring to improve URL handling in the plugin. The main changes involve adding a configuration option for rewritable protocols, enhancing URL detection and filtering logic, and implementing a new mechanism to rewrite links dynamically.

### New Feature: Protocol Rewriting
* **`plugin.json`**: Added a new configuration option, `RewriteProtocolList`, which allows specifying protocols to rewrite in plain text links. These protocols are rewritten to prevent autolinking (e.g., `tel:1234` becomes `tel(1234)`) and are treated as allowed for plain text links.
* **`server/plugin.go`**: Introduced a `rewriteLinks` function to dynamically rewrite plain text links based on the `RewriteProtocolList` configuration. Also added a new `detectedURL` struct to encapsulate URL metadata for processing. [[1]](diffhunk://#diff-43f9ea431ff164da5166ef1e23e4a37f80777429b6803d8303b07b555cb1c1cfR6-R22) [[2]](diffhunk://#diff-43f9ea431ff164da5166ef1e23e4a37f80777429b6803d8303b07b555cb1c1cfL115-R221)

### Configuration and Initialization Updates
* **`server/configuration.go`**: Updated the configuration struct to include `RewriteProtocolList`. Added logic to parse and initialize this list during configuration changes. [[1]](diffhunk://#diff-065f09c83ba4f3083feef6a8ea1f19ab382d993d8cb51045b63a329c07c51ea0R31) [[2]](diffhunk://#diff-065f09c83ba4f3083feef6a8ea1f19ab382d993d8cb51045b63a329c07c51ea0R93-R96) [[3]](diffhunk://#diff-065f09c83ba4f3083feef6a8ea1f19ab382d993d8cb51045b63a329c07c51ea0R113-R116)

### Refactoring and Enhancements
* **`server/plugin.go`**: Refactored URL extraction and validation into separate methods (`extractURLs` and `getInvalidProtocols`). This improves modularity and makes the code easier to maintain. [[1]](diffhunk://#diff-43f9ea431ff164da5166ef1e23e4a37f80777429b6803d8303b07b555cb1c1cfR36-R146) [[2]](diffhunk://#diff-43f9ea431ff164da5166ef1e23e4a37f80777429b6803d8303b07b555cb1c1cfL115-R221)
* **`server/util/util.go`**: Added a utility function `TrimString` to remove empty spaces from strings in a slice, simplifying string processing.

### Test Updates
* **`server/configuration_test.go`**: Updated tests to accommodate the new `RewriteProtocolList` configuration. Adjusted the `newTestPlugin` function to include an additional parameter for this configuration.